### PR TITLE
Exception handling for Gdk::PixbufError

### DIFF
--- a/src/app_icons.cpp
+++ b/src/app_icons.cpp
@@ -212,6 +212,10 @@ Glib::RefPtr<Gdk::Pixbuf> get_pixbuf(Id id, const Gtk::IconSize& size)
 			MLIB_LE();
 		}
 	}
+	//Без этого исключения программа не запускается, если файл изображения повреждён
+	catch(const Gdk::PixbufError & e){
+		g_message("Gdk::PixbufError maybe some image files are corrupted");
+	}
 }
 
 


### PR DESCRIPTION
Добавил одно исключение, без которого flush не запускается если некоторые файлы изоображений повреждены.
